### PR TITLE
fixes encode error for facet-query

### DIFF
--- a/scalyr
+++ b/scalyr
@@ -443,7 +443,7 @@ def printFacetResults(matchCount, values, outputFormat, rawResponse, response):
         csvWriter.writerow(['count', 'value'])
         for i in range(len(values)):
             valueAndCount = values[i]
-            csvWriter.writerow([valueAndCount.get('count'), valueAndCount.get('value')])
+            csvWriter.writerow([valueAndCount.get('count'), unicode(valueAndCount.get('value')).encode("utf-8")])
         print(csvBuffer.getvalue())
 
 


### PR DESCRIPTION
fixes the "UnicodeEncodeError: 'ascii' codec can't encode character" error for facet-query when the results have unicode characters
