### PR TITLE
Fixed verbose option for query

### DIFF
--- a/scalyr
+++ b/scalyr
@@ -43,7 +43,7 @@ def getApiToken(args, environmentVariableName, permissionType):
 
 # Print a string to stderr.
 def print_stderr(message):
-    sys.stderr.write(message + '\n')
+    sys.stderr.write(str(message) + '\n')
 
 # Send a request to the server, and return the parsed JSON response.
 # args: Our parsed command-line arguments


### PR DESCRIPTION
Query command fails in verbose mode while trying to log request headers.
This happens due to type mismatch.

```
./scalyr query 'Error' --verbose
Using arguments: Namespace(columns='', command='query', count=10, end='', filter='Error', mode='', output='multiline', priority='high', server='https://www.scalyr.com', start='', token='', verbose=True)
Connecting to www.scalyr.com via https
Request headers:
Traceback (most recent call last):
  File "./scalyr", line 591, in <module>
    command_func(parser)
  File "./scalyr", line 218, in commandQuery
    "priority": args.priority
  File "./scalyr", line 86, in sendRequest
    print_stderr(headers)
  File "./scalyr", line 46, in print_stderr
    sys.stderr.write(message + '\n')
TypeError: unsupported operand type(s) for +: 'dict' and 'str'
```
