### PR TITLE
Adds a delete-file command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Command-line tool for accessing Scalyr services. The following commands are curr
 - [**create-timeseries**](#creating-timeseries): Create a timeseries for fast numeric queries
 - [**get-file**](#retrieving-configuration-files): Fetch a configuration file
 - [**put-file**](#creating-or-updating-configuration-files): Create or update a configuration file
+- [**delete-file**](#creating-or-updating-configuration-files): Create or update a configuration file
 - [**list-files**](#listing-configuration-files): List all configuration files
 - [**tail**](#tailing-logs): Provide a live 'tail' of a log
 
@@ -412,6 +413,10 @@ Complete argument list:
     --verbose
         Writes detailed progress information to stderr.
 
+The "delete-file" command allows you to delete a configuration file:
+
+    # Delete the "Foo" dashboard
+    scalyr delete-file /scalyr/dashboards/Foo
 
 ## Listing configuration files
 

--- a/scalyr
+++ b/scalyr
@@ -164,6 +164,23 @@ def commandPutFile(parser):
     # Print the file content.
     print_stderr('File "%s" updated' % (args.filepath))
 
+# Implement the "scalyr delete-file" command.
+def commandDeleteFile(parser):
+    # Parse the command-line arguments.
+    parser.add_argument('filepath',
+                        help='server pathname of the file to delete, e.g. "/scalyr/alerts"')
+    args = parser.parse_args()
+
+    # Send the request to the server.
+    response, rawResponse = sendRequest(args, '/putFile', {
+        "token": getApiToken(args, 'scalyr_writeconfig_token', 'Write Config'),
+        "path": args.filepath,
+        "deleteFile": True
+    })
+
+    # Print the file content.
+    print_stderr('File "%s" deleted' % (args.filepath))
+
 
 # Implement the "scalyr list-files" command.
 def commandListFiles(parser):
@@ -562,6 +579,7 @@ if __name__ == '__main__':
       'create-timeseries': commandCreateTimeseries,
       'get-file': commandGetFile,
       'put-file': commandPutFile,
+      'delete-file': commandDeleteFile,
       'list-files': commandListFiles,
     }
 


### PR DESCRIPTION
I've noticed that there is no `delete-file` command so I implemented one based on the [API Documentation](https://www.scalyr.com/help/api). 

It is just a slightly modified version of `put-file` to add a `deleteFile: true` option.