### PR TITLE
Fix #! python -> python2

### DIFF
--- a/scalyr
+++ b/scalyr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Scalyr command-line utility
 


### PR DESCRIPTION
- `python` happens to be `python3` on my system, which breaks on `unicode(...)` when trying to run this script
- This fix changes `#!` to use `python2` instead of `python` to avoid this 3/2 confusion