### PR TITLE
Fully excise the (deprecated) create-timeseries command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Command-line tool for accessing Scalyr services. The following commands are curr
 - [**delete-file**](#creating-or-updating-configuration-files): Delete a configuration file
 - [**list-files**](#listing-configuration-files): List all configuration files
 - [**tail**](#tailing-logs): Provide a live 'tail' of a log
-- [**create-timeseries**](#creating-timeseries): **Deprecated** Create a timeseries for fast numeric queries
 
 
 ## Installation
@@ -339,9 +338,6 @@ Complete argument list:
         Specifies the execution priority for this query; defaults to "high". Use "low" for scripted
         operations where a delay of a second or so is acceptable. Rate limits are tighter for high-
         priority queries.
-     --timeseries=xxx
-        Deprecated. The id of the timeseries to query, as returned by create-timeseries; if present the
-        'filter' and 'function' arguments will be ignored
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
     --version
@@ -349,17 +345,6 @@ Complete argument list:
     --verbose
         Writes detailed progress information to stderr.
 
-
-## Creating timeseries
-
-This method is deprecated, and will eventually be removed from the Scalyr API.
-
-`createTimeseries` creates a timeseries, and returns a numeric ID which can be passed to the
-[`timeseries-query`](#fetching-numeric-data-using-a-timeseries)  API without specifying `filter` and `function` arguments.
-
-Instead of using `create-timeseries`, you should specify `filter` and `function` arguments directly when using `timeseries-query`.
-
-If necessary, documentation for this method is available in the git history =)
 
 
 

--- a/scalyr
+++ b/scalyr
@@ -538,10 +538,8 @@ def commandFacetQuery(parser):
 # Implement the "scalyr timeseries-query" command.
 def commandTimeseriesQuery(parser):
     # Parse the command-line arguments.
-    parser.add_argument('--timeseries', default='', 
-                        help='ID of the timeseries to query')
-    parser.add_argument('filter', nargs='*', default='',
-                        help='search term or filter expression, used only if --timeseries is not provided')
+    parser.add_argument('filter', nargs=1, default='',
+                        help='search term or filter expression')
     parser.add_argument('--function', default='',
                         help='the value to compute from the events matching the filter, used only if --timeseries is not provided')
     parser.add_argument('--start', required=True,
@@ -559,53 +557,25 @@ def commandTimeseriesQuery(parser):
     # Get the API token.
     apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs')
 
-		# build the query, in either flavor
+		# build the query
     query = {
         "queryType": "numeric",
+        "filter": args.filter[0],
+        "function": args.function,
         "startTime": args.start,
         "endTime": args.end,
         "buckets": args.buckets,
         "priority": args.priority
         }
-    
-    if args.timeseries == '':
-        query["filter"] = args.filter[0]
-        query["function"] = args.function
-    else:
-        query["timeseriesId"] = args.timeseries
-
 
     # Send the query to the server.
     response, rawResponse = sendRequest(args, '/api/timeseriesQuery', {
         "token": apiToken,
-        "queries": [ query ] 
+        "queries": [ query ]
     })
 
     # Print the results.
     printNumericResults(response['results'][0]['values'], args.output, rawResponse, response)
-
-
-# Implement the "scalyr create-timeseries" command.
-def commandCreateTimeseries(parser):
-    # Parse the command-line arguments.
-    parser.add_argument('filter', nargs=1, default='',
-                        help='search term or filter expression')
-    parser.add_argument('--function', default='',
-                        help='the value to compute from the events matching the filter')
-    args = parser.parse_args()
-
-    # Get the API token.
-    apiToken = getApiToken(args, 'scalyr_writeconfig_token', 'Write Config')
-
-    # Send the query to the server.
-    response, rawResponse = sendRequest(args, '/api/createTimeseries', {
-        "token": apiToken,
-        "queryType": "numeric",
-        "filter": args.filter[0],
-        "function": args.function
-    })
-
-    print(response['timeseriesId'])
 
 
 if __name__ == '__main__':
@@ -617,7 +587,6 @@ if __name__ == '__main__':
       'facet-query': commandFacetQuery,
       'timeseries-query': commandTimeseriesQuery,
       'timerseries-query': commandTimeseriesQuery,  # mispelling; kept for backwards compatibility
-      'create-timeseries': commandCreateTimeseries,
       'get-file': commandGetFile,
       'put-file': commandPutFile,
       'delete-file': commandDeleteFile,


### PR DESCRIPTION
At some point a pythonista should unify argument->payload packaging bits in `commandNumericQuery` and `commandTimeseriesQuery`, but that's deferrable.