### PR TITLE
FRONT-6832 add onlyUseSummaries and createSummaries timeseries flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ A numeric query is a special case of a [timeseries-query](#fetching-numeric-data
 `--no-createSummaries`. If you will be invoking the same query repeatedly (e.g. in a script), 
 you may want to use the timeseries query command rather than `numeric-query`.
 
-The commands take the same options and return the same data, but for `timeseries-query` invocations we create a
-timeseries on the backend for each unique filter/function pair.  Timeseries queries execute near-instantaneously, and
-avoid exhausting your query execution limit (see below).
+The commands take the same options and return the same data, but for `timeseries-query` invocations without
+`--no-createSummaries` we create a timeseries on the backend for each unique filter/function pair.  
+This query will execute near-instantaneously, and avoid exhausting your query execution limit (see below).
 
 Here are some usage examples:
 
@@ -378,11 +378,11 @@ To change this behavior, use `--no-createSummaries`.
 
 A related flag, `--onlyUseSummaries`, controls whether this API call should only use preexisting timeseries or should
 actually execute the queries against the event database. If the flag is used, then your API call is guaranteed to return
-quickly and to execute inexpensively, but with possibly-incomplete results. If set to false, the call  is slower
+quickly and to execute inexpensively, but with possibly empty results. If set to false, the call  is slower
 & more expensive, but will be complete.
 Issuing a new query over the past 3 weeks with `--onlyUseSummaries` will return quickly
-no matter what, but will initially return incomplete results until backfill (covering the past 3 weeks) is complete.
-This can be a cost-effective way to seed a new timeseries with a long backfill period when you don't need complete
+no matter what, but will initially return empty results until backfill (covering the past 3 weeks) is complete.
+This can be a cost-effective way to seed a new timeseries with a long backfill period when you don't need
 results right away.
 
 Issuing a timeseries command with `--no-createSummaries` is equivalent to a [numeric-query](#Fetching numeric data) command.
@@ -430,8 +430,9 @@ Complete argument list:
         priority queries.
     --onlyUseSummaries
         Specifies to only query summaries, and not to search the column store for any summaries not yet populated.
+        No results will be returned unless the summaries queried have been backfilled. 
     --no-createSummaries
-        Specifies to not create summaries for this query.
+        Specifies to not create summaries for this query. 
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
     --version

--- a/README.md
+++ b/README.md
@@ -233,12 +233,12 @@ The "numeric-query" command allows you to retrieve numeric data, e.g. for graphi
 rate of events matching some criterion (e.g. error rate), or retrieve a numeric field (e.g. response
 size). 
 
-A numeric query is a special case of a [timeseries-query](#fetching-numeric-data-using-a-timeseries) with flag
-`--no-createSummaries`. If you will be invoking the same query repeatedly (e.g. in a script), 
+A numeric query is a special case of a [timeseries-query](#fetching-numeric-data-using-a-timeseries) with argument
+`--no-create-summaries`. If you will be invoking the same query repeatedly (e.g. in a script), 
 you may want to use the timeseries query command rather than `numeric-query`.
 
 The commands take the same options and return the same data, but for `timeseries-query` invocations without
-`--no-createSummaries` we create a timeseries on the backend for each unique filter/function pair.  
+`--no-create-summaries` we create a timeseries on the backend for each unique filter/function pair.  
 This query will execute near-instantaneously, and avoid exhausting your query execution limit (see below).
 
 Here are some usage examples:
@@ -374,18 +374,18 @@ When a new timeseries is defined, we immediately start live updating of that tim
 In addition, we begin a background process to extend the timeseries backward in time, so that it covers the full
 timespan of your query. This backfill process is automatic, and if you later issue the same query with an even
 earlier start time, we will extend the backfill to cover that as well.
-To change this behavior, use `--no-createSummaries`.
+To change this behavior, use `--no-create-summaries`.
 
-A related flag, `--onlyUseSummaries`, controls whether this API call should only use preexisting timeseries or should
-actually execute the queries against the event database. If the flag is used, then your API call is guaranteed to return
+A related argument, `--only-use-summaries`, controls whether this API call should only use preexisting timeseries or should
+actually execute the queries against the event database. If the argument is used, then your API call is guaranteed to return
 quickly and to execute inexpensively, but with possibly empty results. If set to false, the call  is slower
 & more expensive, but will be complete.
-Issuing a new query over the past 3 weeks with `--onlyUseSummaries` will return quickly
+Issuing a new query over the past 3 weeks with `--only-use-summaries` will return quickly
 no matter what, but will initially return empty results until backfill (covering the past 3 weeks) is complete.
 This can be a cost-effective way to seed a new timeseries with a long backfill period when you don't need
 results right away.
 
-Issuing a timeseries command with `--no-createSummaries` is equivalent to a [numeric-query](#Fetching numeric data) command.
+Issuing a timeseries command with `--no-create-summaries` is equivalent to a [numeric-query](#Fetching numeric data) command.
 
 Usage is identical to the numeric-query command:
 
@@ -394,7 +394,7 @@ Usage is identical to the numeric-query command:
 Complete argument list:
 
     scalyr timeseries-query [filter] [--function xxx] --start xxx [options...]
-        Just like numeric-query if `--no-createSummaries` is specified. Otherwise Scalyr will create a timeseries for
+        Just like numeric-query if `--no-create-summaries` is specified. Otherwise Scalyr will create a timeseries for
         you in the background.
 
     scalyr timeseries-query --timeseries <timeseriesid> --start xxx [options...]
@@ -428,10 +428,10 @@ Complete argument list:
         Specifies the execution priority for this query; defaults to "high". Use "low" for scripted
         operations where a delay of a second or so is acceptable. Rate limits are tighter for high-
         priority queries.
-    --onlyUseSummaries
+    --only-use-summaries
         Specifies to only query summaries, and not to search the column store for any summaries not yet populated.
         No results will be returned unless the summaries queried have been backfilled. 
-    --no-createSummaries
+    --no-create-summaries
         Specifies to not create summaries for this query. 
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.

--- a/README.md
+++ b/README.md
@@ -231,10 +231,12 @@ If the clocks on the servers sending log messages to Scalyr are significantly ou
 
 The "numeric-query" command allows you to retrieve numeric data, e.g. for graphing. You can count the
 rate of events matching some criterion (e.g. error rate), or retrieve a numeric field (e.g. response
-size).
+size). 
 
-If you will be invoking the same query repeatedly (e.g. in a script), you may want to use the
-[`timeseries-query`](#fetching-numeric-data-using-a-timeseries) command rather than `numeric-query`.
+A numeric query is a special case of a [timeseries-query](#fetching-numeric-data-using-a-timeseries) with flags
+`createSummaries = false`, `onlyUseSummaries = false`. If you will be invoking the same query repeatedly (e.g. in a script), 
+you may want to use the timeseries query command with `createSummaries = true` (as is default) rather than 
+`numeric-query`.
 
 The commands take the same options and return the same data, but for `timeseries-query` invocations we create a
 timeseries on the backend for each unique filter/function pair.  Timeseries queries execute near-instantaneously, and
@@ -384,7 +386,7 @@ no matter what, but will initially return incomplete results until backfill (cov
 This can be a cost-effective way to seed a new timeseries with a long backfill period when you don't need complete
 results right away.
 
-Issuing a query with `createSummaries = false`, `onlyUseSummaries = false` is equivalent to a [`numeric-query`](#Fetching numeric data) call.
+Issuing a timeseries command with `createSummaries = false`, `onlyUseSummaries = false` is equivalent to a [numeric-query](#Fetching numeric data) command.
 
 Usage is identical to the numeric-query command:
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ you may want to use the timeseries query command rather than `numeric-query`.
 
 The commands take the same options and return the same data, but for `timeseries-query` invocations without
 `--no-create-summaries` we create a timeseries on the backend for each unique filter/function pair.  
-This query will execute near-instantaneously, and avoid exhausting your query execution limit (see below).
+This query will execute near-instantaneously, and avoid consuming your account's query budget (see below).
 
 Here are some usage examples:
 

--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ The "numeric-query" command allows you to retrieve numeric data, e.g. for graphi
 rate of events matching some criterion (e.g. error rate), or retrieve a numeric field (e.g. response
 size). 
 
-A numeric query is a special case of a [timeseries-query](#fetching-numeric-data-using-a-timeseries) with argument
-`--no-create-summaries`. If you will be invoking the same query repeatedly (e.g. in a script), 
+A numeric query is equivalent to a [timeseries-query](#fetching-numeric-data-using-a-timeseries) with argument
+`--no-create-summaries` and without `--only-use-summaries`. If you will be invoking the same query repeatedly (e.g. in a script), 
 you may want to use the timeseries query command rather than `numeric-query`.
 
 The commands take the same options and return the same data, but for `timeseries-query` invocations without
@@ -365,7 +365,7 @@ If you need a higher limit, drop us a line at support@scalyr.com.
 ## Fetching numeric data using a timeseries
 
 A timeseries precomputes a numeric query, allowing you to execute queries almost instantaneously, and without
-exhausting your query execution limit.  This is especially useful if you are using the Scalyr API to feed a
+consuming your account's query budget.  This is especially useful if you are using the Scalyr API to feed a
 home-built dashboard, alerting system, or other automated tool. Note that the [Scalyr API](https://www.scalyr.com/help/api#timeseriesQuery)
 allows multiple timeseries queries in a single API invocation, but the command-line tool only supports
 one query at a time.
@@ -377,15 +377,16 @@ earlier start time, we will extend the backfill to cover that as well.
 To change this behavior, use `--no-create-summaries`.
 
 A related argument, `--only-use-summaries`, controls whether this API call should only use preexisting timeseries or should
-actually execute the queries against the event database. If the argument is used, then your API call is guaranteed to return
-quickly and to execute inexpensively, but with possibly empty results. If set to false, the call  is slower
-& more expensive, but will be complete.
-Issuing a new query over the past 3 weeks with `--only-use-summaries` will return quickly
+execute the queries against the event database if no matching summary exists. If this argument is used, then your API call 
+is guaranteed to return quickly and to execute inexpensively, but with possibly empty results. If this argument is not used, 
+the call may be slower & more expensive, but will be complete.
+For example, issuing a new query over the past 3 weeks with `--only-use-summaries` will return quickly
 no matter what, but will initially return empty results until backfill (covering the past 3 weeks) is complete.
 This can be a cost-effective way to seed a new timeseries with a long backfill period when you don't need
 results right away.
 
-Issuing a timeseries command with `--no-create-summaries` is equivalent to a [numeric-query](#Fetching numeric data) command.
+Issuing a timeseries command with `--no-create-summaries` and without `--only-use-summaries` is equivalent to a
+[numeric-query](#Fetching numeric data) command.
 
 Usage is identical to the numeric-query command:
 

--- a/README.md
+++ b/README.md
@@ -233,10 +233,9 @@ The "numeric-query" command allows you to retrieve numeric data, e.g. for graphi
 rate of events matching some criterion (e.g. error rate), or retrieve a numeric field (e.g. response
 size). 
 
-A numeric query is a special case of a [timeseries-query](#fetching-numeric-data-using-a-timeseries) with flags
-`createSummaries = false`, `onlyUseSummaries = false`. If you will be invoking the same query repeatedly (e.g. in a script), 
-you may want to use the timeseries query command with `createSummaries = true` (as is default) rather than 
-`numeric-query`.
+A numeric query is a special case of a [timeseries-query](#fetching-numeric-data-using-a-timeseries) with flag
+`--no-createSummaries`. If you will be invoking the same query repeatedly (e.g. in a script), 
+you may want to use the timeseries query command rather than `numeric-query`.
 
 The commands take the same options and return the same data, but for `timeseries-query` invocations we create a
 timeseries on the backend for each unique filter/function pair.  Timeseries queries execute near-instantaneously, and
@@ -375,18 +374,18 @@ When a new timeseries is defined, we immediately start live updating of that tim
 In addition, we begin a background process to extend the timeseries backward in time, so that it covers the full
 timespan of your query. This backfill process is automatic, and if you later issue the same query with an even
 earlier start time, we will extend the backfill to cover that as well.
-To change this behavior, set `createSummaries` to false.
+To change this behavior, use `--no-createSummaries`.
 
-A related flag, `onlyUseSummaries`, controls whether this API call should only use preexisting timeseries or should
-actually execute the queries against the event database. If set to true, then your API call is guaranteed to return
+A related flag, `--onlyUseSummaries`, controls whether this API call should only use preexisting timeseries or should
+actually execute the queries against the event database. If the flag is used, then your API call is guaranteed to return
 quickly and to execute inexpensively, but with possibly-incomplete results. If set to false, the call  is slower
 & more expensive, but will be complete.
-Issuing a new query over the past 3 weeks with `createSummaries = true`, `onlyUseSummaries = true` will return quickly
+Issuing a new query over the past 3 weeks with `--onlyUseSummaries` will return quickly
 no matter what, but will initially return incomplete results until backfill (covering the past 3 weeks) is complete.
 This can be a cost-effective way to seed a new timeseries with a long backfill period when you don't need complete
 results right away.
 
-Issuing a timeseries command with `createSummaries = false`, `onlyUseSummaries = false` is equivalent to a [numeric-query](#Fetching numeric data) command.
+Issuing a timeseries command with `--no-createSummaries` is equivalent to a [numeric-query](#Fetching numeric data) command.
 
 Usage is identical to the numeric-query command:
 
@@ -395,7 +394,8 @@ Usage is identical to the numeric-query command:
 Complete argument list:
 
     scalyr timeseries-query [filter] [--function xxx] --start xxx [options...]
-        Just like numeric-query, but with Scalyr creating a timeseries for you in the background, unless `createSummaries = false`
+        Just like numeric-query if `--no-createSummaries` is specified. Otherwise Scalyr will create a timeseries for
+        you in the background.
 
     scalyr timeseries-query --timeseries <timeseriesid> --start xxx [options...]
         To query a timeseries created using create-timeseries 
@@ -428,11 +428,10 @@ Complete argument list:
         Specifies the execution priority for this query; defaults to "high". Use "low" for scripted
         operations where a delay of a second or so is acceptable. Rate limits are tighter for high-
         priority queries.
-    --onlyUseSummaries=true|false
-        Specifies whether to only query summaries, or to search the column store for any summaries not yet populated.
-        Defaults to false.
-    --createSummaries=true|false
-        Specifies whether to create summaries for this query if they do not already exist. Defaults to true.
+    --onlyUseSummaries
+        Specifies to only query summaries, and not to search the column store for any summaries not yet populated.
+    --no-createSummaries
+        Specifies to not create summaries for this query.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
     --version

--- a/scalyr
+++ b/scalyr
@@ -664,10 +664,10 @@ def commandTimeseriesQuery(parser):
                         help='specifies the format in which numbers are emitted')
     parser.add_argument('--priority', choices=['high', 'low'], default='high',
                         help='specifies the execution priority for this query. Use low for scripted operations where a delay of a second or so is acceptable.')
-    parser.add_argument('--useOnlySummaries', choices=['true', 'false'], default='false',
-                        help='specifies whether to only query summaries, or to search the column store for any summaries not yet populated')
-    parser.add_argument('--createSummaries', choices=['true', 'false'], default='true',
-                        help='specifies whether to create summaries for this query if they do not already exist')
+    parser.add_argument('--onlyUseSummaries', action='store_true', default=False,
+                        help='specifies to query only summaries, and will not search the column store for any summaries not yet populated')
+    parser.add_argument('--no-createSummaries', dest='createSummaries', action='store_false', default=True,
+                        help='specifies to not create summaries for this query')
     args = parser.parse_args()
 
     # Get the API token.

--- a/scalyr
+++ b/scalyr
@@ -209,6 +209,7 @@ def commandGetFile(parser):
         "path": args.filepath,
     })
 
+
     # Print the file content.
     if response['status'] == 'success/noSuchFile':
         print_stderr('File "%s" does not exist' % (args.filepath))
@@ -663,6 +664,10 @@ def commandTimeseriesQuery(parser):
                         help='specifies the format in which numbers are emitted')
     parser.add_argument('--priority', choices=['high', 'low'], default='high',
                         help='specifies the execution priority for this query. Use low for scripted operations where a delay of a second or so is acceptable.')
+    parser.add_argument('--useOnlySummaries', choices=['true', 'false'], default='false',
+                        help='specifies whether to only query summaries, or to search the column store for any summaries not yet populated')
+    parser.add_argument('--createSummaries', choices=['true', 'false'], default='true',
+                        help='specifies whether to create summaries for this query if they do not already exist')
     args = parser.parse_args()
 
     # Get the API token.
@@ -676,7 +681,9 @@ def commandTimeseriesQuery(parser):
         "startTime": args.start,
         "endTime": args.end,
         "buckets": args.buckets,
-        "priority": args.priority
+        "priority": args.priority,
+        "onlyUseSummaries": args.onlyUseSummaries,
+        "createSummaries": args.createSummaries
         }
 
     # Send the query to the server.

--- a/scalyr
+++ b/scalyr
@@ -666,6 +666,8 @@ def commandTimeseriesQuery(parser):
                         help='specifies the execution priority for this query. Use low for scripted operations where a delay of a second or so is acceptable.')
     parser.add_argument('--only-use-summaries', dest='onlyUseSummaries', action='store_true', default=False,
                         help='specifies to query only summaries, and will not search the column store for any summaries not yet populated')
+
+    # Note: we are inverting this (negative) argument into args.createSummaries. Use of this argument will set createSummaries = False in the query.
     parser.add_argument('--no-create-summaries', dest='createSummaries', action='store_false', default=True,
                         help='specifies to not create summaries for this query')
     args = parser.parse_args()

--- a/scalyr
+++ b/scalyr
@@ -209,7 +209,6 @@ def commandGetFile(parser):
         "path": args.filepath,
     })
 
-
     # Print the file content.
     if response['status'] == 'success/noSuchFile':
         print_stderr('File "%s" does not exist' % (args.filepath))

--- a/scalyr
+++ b/scalyr
@@ -664,9 +664,9 @@ def commandTimeseriesQuery(parser):
                         help='specifies the format in which numbers are emitted')
     parser.add_argument('--priority', choices=['high', 'low'], default='high',
                         help='specifies the execution priority for this query. Use low for scripted operations where a delay of a second or so is acceptable.')
-    parser.add_argument('--onlyUseSummaries', action='store_true', default=False,
+    parser.add_argument('--only-use-summaries', dest='onlyUseSummaries', action='store_true', default=False,
                         help='specifies to query only summaries, and will not search the column store for any summaries not yet populated')
-    parser.add_argument('--no-createSummaries', dest='createSummaries', action='store_false', default=True,
+    parser.add_argument('--no-create-summaries', dest='createSummaries', action='store_false', default=True,
                         help='specifies to not create summaries for this query')
     args = parser.parse_args()
 


### PR DESCRIPTION
[FRONT-6832](https://scalyr.myjetbrains.com/youtrack/issue/FRONT-6832) Update scalyr-tool with new `timeseriesQuery` flags (`{create,onlyUse}Summaries`).

I tested the revised tool locally and it worked as expected. 

I have one question about existing code below, which is about the `--timeseries` argument, which I can't find being used in the code and results in an "unrecognized arguments" error when I try to use it. Lmk if I should remove reference to this argument in the readme. 