### PR TITLE
FRONT-6857 remove refs to --timeseries arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,10 +397,6 @@ Complete argument list:
     scalyr timeseries-query [filter] [--function xxx] --start xxx [options...]
         Just like numeric-query if `--no-create-summaries` is specified. Otherwise Scalyr will create a timeseries for
         you in the background.
-
-    scalyr timeseries-query --timeseries <timeseriesid> --start xxx [options...]
-        To query a timeseries created using create-timeseries 
-
     --start=xxx
         Specify the beginning of the time range to query. Uses the same syntax as the "Start" field in
         the log view. You must specify this argument.
@@ -408,7 +404,6 @@ Complete argument list:
         Specify the end of the time range to query. Uses the same syntax as the "End" field in the log
         view. Defaults to the current time.
     --function=xxx
-        Only used if --timeseries is not provided.
         The value to compute from the matching events. You can use any function listed in
         https://www.scalyr.com/help/query-language#graphFunctions, except for fraction(expr). For
         example: 'mean(x)' or 'median(responseTime)', if x and responseTime are fields of your log.

--- a/scalyr
+++ b/scalyr
@@ -652,7 +652,7 @@ def commandTimeseriesQuery(parser):
     parser.add_argument('filter', nargs=1, default='',
                         help='search term or filter expression')
     parser.add_argument('--function', default='',
-                        help='the value to compute from the events matching the filter, used only if --timeseries is not provided')
+                        help='the value to compute from the events matching the filter')
     parser.add_argument('--start', required=True,
                         help='beginning of the time range to query')
     parser.add_argument('--end', default='',


### PR DESCRIPTION
[FRONT-6857](https://scalyr.myjetbrains.com/youtrack/issue/FRONT-6857) Remove references to deprecated `create-timeseries` command and `--timeseries` argument in scalyr-tool