### PR TITLE
Create separate function for CLI main

### DIFF
--- a/scalyr
+++ b/scalyr
@@ -697,7 +697,7 @@ def commandTimeseriesQuery(parser):
     printNumericResults(response['results'][0]['values'], args.output, rawResponse, response)
 
 
-if __name__ == '__main__':
+def scalyrToolCli():
     # All available commands
     all_commands = {
       'query': commandQuery,
@@ -748,3 +748,6 @@ if __name__ == '__main__':
     # object oriented approach.
     command_func = all_commands[command]
     command_func(parser)
+
+if __name__ == '__main__':
+    scalyrToolCli()


### PR DESCRIPTION
# Background

I'm reusing this source for a GitHub Actions project.  Since this repo is not set up as a true Python module, it is a little difficult to reuse it in another project.  I think probably we should move it to a true Python module in the long term, but that would impact the ease of use of just having this as a standalone script.

This was the smallest change I could make to allow me to reuse this in another project.

# Change

Create a function to perform most of the work
to handle the commandline interface and invoke
that if run as a script.
