### PR TITLE
Fix hour handling for local TZ purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.claude
 .idea

--- a/scalyr
+++ b/scalyr
@@ -70,23 +70,27 @@ def _is_relative_time(s):
 
 
 def _parse_time_component(s):
-    """Parse a time like '9am', '12pm'. Returns (hour, True) or (None, False)."""
+    """Parse a time like '9am', '12pm', '10:30am'. Returns (hour, minute, True) or (None, None, False)."""
     s = s.lower().strip()
-    if s.endswith('am'):
-        time_part = s[:-2]
-        if time_part.isdigit():
-            hour = int(time_part)
-            if hour == 12:
-                hour = 0
-            return (hour, True)
-    elif s.endswith('pm'):
-        time_part = s[:-2]
-        if time_part.isdigit():
-            hour = int(time_part)
-            if hour != 12:
+    for suffix, is_pm in [('am', False), ('pm', True)]:
+        if s.endswith(suffix):
+            time_part = s[:-len(suffix)]
+            if ':' in time_part:
+                parts = time_part.split(':')
+                if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+                    hour, minute = int(parts[0]), int(parts[1])
+                else:
+                    continue
+            elif time_part.isdigit():
+                hour, minute = int(time_part), 0
+            else:
+                continue
+            if is_pm and hour != 12:
                 hour += 12
-            return (hour, True)
-    return (None, False)
+            elif not is_pm and hour == 12:
+                hour = 0
+            return (hour, minute, True)
+    return (None, None, False)
 
 
 def _parse_date_component(s):
@@ -127,12 +131,12 @@ def _format_iso8601(dt, offset_seconds):
     return dt.strftime('%Y-%m-%dT%H:%M:%S') + offset_str
 
 
-def _find_most_recent_day_time(now, target_weekday, hour):
+def _find_most_recent_day_time(now, target_weekday, hour, minute=0):
     """Find the most recent occurrence of a specific day and hour."""
     current_weekday = now.weekday()
     days_back = (current_weekday - target_weekday) % 7
 
-    candidate = datetime.datetime(now.year, now.month, now.day, hour, 0, 0) - datetime.timedelta(days=days_back)
+    candidate = datetime.datetime(now.year, now.month, now.day, hour, minute, 0) - datetime.timedelta(days=days_back)
 
     # If the candidate is in the future, go back a week
     if candidate > now:
@@ -141,9 +145,9 @@ def _find_most_recent_day_time(now, target_weekday, hour):
     return candidate
 
 
-def _find_most_recent_time(now, hour):
-    """Find the most recent occurrence of a specific hour."""
-    candidate = datetime.datetime(now.year, now.month, now.day, hour, 0, 0)
+def _find_most_recent_time(now, hour, minute=0):
+    """Find the most recent occurrence of a specific hour and minute."""
+    candidate = datetime.datetime(now.year, now.month, now.day, hour, minute, 0)
 
     # If the candidate is in the future, go back a day
     if candidate > now:
@@ -181,19 +185,19 @@ def parse_timestamp(timestamp_str):
         # Check first part for day name
         if parts[0] in _DAY_NAMES:
             day_name = parts[0]
-            hour, ok = _parse_time_component(parts[1])
+            hour, minute, ok = _parse_time_component(parts[1])
             if not ok:
                 hour = None
         # Check second part for day name
         elif parts[1] in _DAY_NAMES:
             day_name = parts[1]
-            hour, ok = _parse_time_component(parts[0])
+            hour, minute, ok = _parse_time_component(parts[0])
             if not ok:
                 hour = None
 
         if day_name is not None and hour is not None:
             target_weekday = _DAY_NAMES[day_name]
-            parsed_dt = _find_most_recent_day_time(now, target_weekday, hour)
+            parsed_dt = _find_most_recent_day_time(now, target_weekday, hour, minute)
 
     elif len(parts) == 1:
         # Single token: could be day name, time, or date
@@ -203,10 +207,10 @@ def parse_timestamp(timestamp_str):
             target_weekday = _DAY_NAMES[s_lower]
             parsed_dt = _find_most_recent_day_time(now, target_weekday, 0)
         else:
-            # Check for time only (e.g., "9am", "12pm")
-            hour, ok = _parse_time_component(s_lower)
+            # Check for time only (e.g., "9am", "12pm", "10:30am")
+            hour, minute, ok = _parse_time_component(s_lower)
             if ok:
-                parsed_dt = _find_most_recent_time(now, hour)
+                parsed_dt = _find_most_recent_time(now, hour, minute)
             else:
                 # Check for date (e.g., "3/1/26")
                 year, month, day, ok = _parse_date_component(timestamp_str)


### PR DESCRIPTION
'9am' and 'Monday 9am' worked, but '--start 10:30am'  was passed through unchanged.

That is now fixed:

<img width="762" height="269" alt="image" src="https://github.com/user-attachments/assets/23a5b879-02d6-44a9-8406-462200c7e955" />
