### PR TITLE
Add support to read token from stdin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 .claude
 .idea
+.vscode
+.DS_Store
+
+# byte-compiled and optimized python files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/README.md
+++ b/README.md
@@ -36,18 +36,14 @@ The values for `XXX`, `YYY`, and `ZZZ` can be found at [scalyr.com/keys](https:/
 for "Read Logs", "Read Config", and "Write Config" tokens, respectively.
 
 For situations where neither argv nor a persistent environment variable is acceptable (e.g. long-running
-queries visible in `ps aux`, or CI pipelines), two safer alternatives are available:
+queries visible in `ps aux`, or CI pipelines), use `--token -` to read the token from stdin. The token never appears in
+the process argument list.
 
-- `--token-stdin` -- pipe the token into the tool on stdin. The token never appears in the process
-  argument list. This works for all commands except `put-file`, which reads file content from stdin.
+    security find-generic-password -a "<my_user>" -s "<some_key>" -w \
+      | scalyr query '<my_query>' --token -
 
-      security find-generic-password -a "$USER" -s "dataset-api-key-myteam" -w \
-        | scalyr query 'error' --token-stdin
-
-- `--token-fd N` -- pass the token on an already-open file descriptor. Works with all commands,
-  including `put-file`. Use bash's `N< <(...)` redirect syntax to open the fd without touching argv.
-
-      scalyr put-file /scalyr/alerts --token-fd 3 3< <(cat ~/.scalyr-token)
+`--token -` is supported for query commands (`query`, `tail`, `numeric-query`, `facet-query`,
+`power-query`, `timeseries-query`).
 
 Setting a custom Scalyr server can be done using the `--server` argument but also via environment variable:
 
@@ -108,10 +104,6 @@ Complete argument list:
         priority queries.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
-    --token-stdin
-        Read the API token from stdin instead of argv.
-    --token-fd N
-        Read the API token from an already-open file descriptor N.
     --verbose
         Writes detailed progress information to stderr.
     --proxy=<ip>:<port>
@@ -178,10 +170,6 @@ Complete argument list:
         priority queries.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
-    --token-stdin
-        Read the API token from stdin instead of argv.
-    --token-fd N
-        Read the API token from an already-open file descriptor N.
     --verbose
         Writes detailed progress information to stderr.
     --proxy=<ip>:<port>
@@ -240,10 +228,6 @@ Complete argument list:
         Defaults to 'messageonly'.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
-    --token-stdin
-        Read the API token from stdin instead of argv.
-    --token-fd N
-        Read the API token from an already-open file descriptor N.
 
 #### Usage limits
 
@@ -312,10 +296,6 @@ Complete argument list:
         priority queries.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
-    --token-stdin
-        Read the API token from stdin instead of argv.
-    --token-fd N
-        Read the API token from an already-open file descriptor N.
     --version
         Prints the current version number of this tool.
     --verbose
@@ -377,10 +357,6 @@ Complete argument list:
         priority queries.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
-    --token-stdin
-        Read the API token from stdin instead of argv.
-    --token-fd N
-        Read the API token from an already-open file descriptor N.
     --version
         Prints the current version number of this tool.
     --verbose
@@ -467,10 +443,6 @@ Complete argument list:
         Specifies to not create summaries for this query.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
-    --token-stdin
-        Read the API token from stdin instead of argv.
-    --token-fd N
-        Read the API token from an already-open file descriptor N.
     --version
         Prints the current version number of this tool.
     --verbose
@@ -478,8 +450,6 @@ Complete argument list:
     --proxy=<ip>:<port>
         An address to connect through when using a proxy. If not set will also take the value from one of the following
         environment variables if any are set: http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY
-
-
 
 
 ## Retrieving configuration files
@@ -504,10 +474,6 @@ Complete argument list:
         Prints the current version number of this tool.
     --token=xxx
         Specify the API token. For this command, should be a "Read Config" token.
-    --token-stdin
-        Read the API token from stdin instead of argv.
-    --token-fd N
-        Read the API token from an already-open file descriptor N.
     --verbose
         Writes detailed progress information to stderr.
     --proxy=<ip>:<port>
@@ -536,9 +502,6 @@ Complete argument list:
         Prints the current version number of this tool.
     --token=xxx
         Specify the API token. For this command, should be a "Write Config" token.
-    --token-fd N
-        Read the API token from an already-open file descriptor N. (Use this instead of --token-stdin,
-        since put-file reads file content from stdin.)
     --verbose
         Writes detailed progress information to stderr.
     --proxy=<ip>:<port>
@@ -571,10 +534,6 @@ Complete argument list:
         Prints the current version number of this tool.
     --token=xxx
         Specify the API token. For this command, should be a "Read Config" token.
-    --token-stdin
-        Read the API token from stdin instead of argv.
-    --token-fd N
-        Read the API token from an already-open file descriptor N.
     --verbose
         Writes detailed progress information to stderr.
     --proxy=<ip>:<port>

--- a/README.md
+++ b/README.md
@@ -32,8 +32,22 @@ command history. On Unix systems, you can add the following to a file like `.bas
     export scalyr_readconfig_token='YYY'
     export scalyr_writeconfig_token='ZZZ'
 
-The values for XXX, YYY, and ZZZ can be found at [scalyr.com/keys](https://www.scalyr.com/keys) -- look
+The values for `XXX`, `YYY`, and `ZZZ` can be found at [scalyr.com/keys](https://www.scalyr.com/keys) -- look
 for "Read Logs", "Read Config", and "Write Config" tokens, respectively.
+
+For situations where neither argv nor a persistent environment variable is acceptable (e.g. long-running
+queries visible in `ps aux`, or CI pipelines), two safer alternatives are available:
+
+- `--token-stdin` -- pipe the token into the tool on stdin. The token never appears in the process
+  argument list. This works for all commands except `put-file`, which reads file content from stdin.
+
+      security find-generic-password -a "$USER" -s "dataset-api-key-myteam" -w \
+        | scalyr query 'error' --token-stdin
+
+- `--token-fd N` -- pass the token on an already-open file descriptor. Works with all commands,
+  including `put-file`. Use bash's `N< <(...)` redirect syntax to open the fd without touching argv.
+
+      scalyr put-file /scalyr/alerts --token-fd 3 3< <(cat ~/.scalyr-token)
 
 Setting a custom Scalyr server can be done using the `--server` argument but also via environment variable:
 
@@ -94,6 +108,10 @@ Complete argument list:
         priority queries.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
+    --token-stdin
+        Read the API token from stdin instead of argv.
+    --token-fd N
+        Read the API token from an already-open file descriptor N.
     --verbose
         Writes detailed progress information to stderr.
     --proxy=<ip>:<port>
@@ -160,6 +178,10 @@ Complete argument list:
         priority queries.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
+    --token-stdin
+        Read the API token from stdin instead of argv.
+    --token-fd N
+        Read the API token from an already-open file descriptor N.
     --verbose
         Writes detailed progress information to stderr.
     --proxy=<ip>:<port>
@@ -216,6 +238,12 @@ Complete argument list:
         Similar to the multiline and singleline options for the 'query' command, but also has a 'messageonly'
         mode that will only display the raw log message, and not any additional attributes.
         Defaults to 'messageonly'.
+    --token=xxx
+        Specify the API token. For this command, should be a "Read Logs" token.
+    --token-stdin
+        Read the API token from stdin instead of argv.
+    --token-fd N
+        Read the API token from an already-open file descriptor N.
 
 #### Usage limits
 
@@ -284,6 +312,10 @@ Complete argument list:
         priority queries.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
+    --token-stdin
+        Read the API token from stdin instead of argv.
+    --token-fd N
+        Read the API token from an already-open file descriptor N.
     --version
         Prints the current version number of this tool.
     --verbose
@@ -345,6 +377,10 @@ Complete argument list:
         priority queries.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
+    --token-stdin
+        Read the API token from stdin instead of argv.
+    --token-fd N
+        Read the API token from an already-open file descriptor N.
     --version
         Prints the current version number of this tool.
     --verbose
@@ -431,6 +467,10 @@ Complete argument list:
         Specifies to not create summaries for this query.
     --token=xxx
         Specify the API token. For this command, should be a "Read Logs" token.
+    --token-stdin
+        Read the API token from stdin instead of argv.
+    --token-fd N
+        Read the API token from an already-open file descriptor N.
     --version
         Prints the current version number of this tool.
     --verbose
@@ -464,6 +504,10 @@ Complete argument list:
         Prints the current version number of this tool.
     --token=xxx
         Specify the API token. For this command, should be a "Read Config" token.
+    --token-stdin
+        Read the API token from stdin instead of argv.
+    --token-fd N
+        Read the API token from an already-open file descriptor N.
     --verbose
         Writes detailed progress information to stderr.
     --proxy=<ip>:<port>
@@ -492,6 +536,9 @@ Complete argument list:
         Prints the current version number of this tool.
     --token=xxx
         Specify the API token. For this command, should be a "Write Config" token.
+    --token-fd N
+        Read the API token from an already-open file descriptor N. (Use this instead of --token-stdin,
+        since put-file reads file content from stdin.)
     --verbose
         Writes detailed progress information to stderr.
     --proxy=<ip>:<port>
@@ -524,6 +571,10 @@ Complete argument list:
         Prints the current version number of this tool.
     --token=xxx
         Specify the API token. For this command, should be a "Read Config" token.
+    --token-stdin
+        Read the API token from stdin instead of argv.
+    --token-fd N
+        Read the API token from an already-open file descriptor N.
     --verbose
         Writes detailed progress information to stderr.
     --proxy=<ip>:<port>

--- a/scalyr
+++ b/scalyr
@@ -227,18 +227,28 @@ def parse_timestamp(timestamp_str):
 
 
 # Return the API token from the command line or environment variables.
+# Resolution order: --token-stdin / --token-fd > --token > env var
 def getApiToken(args, environmentVariableName, permissionType):
-    apiToken = args.token
-    if apiToken == '':
-        apiToken = os.getenv(environmentVariableName, '')
-    if apiToken == '':
+    fd = 0 if args.token_stdin else args.token_fd  # token_stdin is a convenience alias for fd 0 (stdin)
+    if fd is not None:
+        try:
+            with os.fdopen(fd, 'r') as f:
+                return f.read().strip()
+        except OSError as e:
+            print_stderr('Error reading token from fd %d: %s' % (fd, e))
+            sys.exit(1)
+
+    api_token = args.token
+    if api_token == '':
+        api_token = os.getenv(environmentVariableName, '')
+    if api_token == '':
         print_stderr('Please specify an API token granting ' + permissionType + ' permission. You can place it in the')
         print_stderr('command line as --token "XXX", or in the environment variable "' + environmentVariableName + '".')
         print_stderr('Use of an environment variable is recommended, to avoid displaying your API token in the')
         print_stderr('console or your command history. You can find API tokens at https://www.scalyr.com/keys.')
         sys.exit(1)
 
-    return apiToken
+    return api_token
 
 
 def getProxyAddress(args):
@@ -942,17 +952,19 @@ def scalyrToolCli():
                         help='specifies the action to be performed')
     parser.add_argument('--version', action='version', version='%(prog)s ' + TOOL_VERSION)
     parser.add_argument('--server',
-                        help='URL for the Scalyr API server.  Defaults to https://www.scalyr.com. If you are using eu.scalyr.com then this should be set to https://eu.scalyr.com.')
+                        help='URL for the Scalyr API server. Defaults to https://www.scalyr.com. If you are using eu.scalyr.com then this should be set to https://eu.scalyr.com.')
     parser.add_argument('--token', default='',
                         help='API access token')
+    parser.add_argument('--token-stdin', action='store_true', default=False,
+                        help='Read API token from stdin (avoids argv exposure). Example: echo $TOKEN | scalyr query ... --token-stdin')
+    parser.add_argument('--token-fd', type=int, metavar='FD',  # returns None when not supplied
+                        help='Read API token from an open file descriptor (avoids argv exposure). Example: scalyr query ... --token-fd 3 3< <(cat ~/.scalyr-token)')
     parser.add_argument('--verbose', action='store_true', default=False,
                         help='enables additional diagnostic output')
     parser.add_argument('--dryrun', action='store_true', default=False,
                         help='enables verbose mode and exits after printing the request body without contacting the server')
-
     parser.add_argument('--no-escape-unicode', action="store_false",
                         help='When true, the json-pretty output format will show unicode characters rather than escaped unicode characters (the default for json-pretty is to use escaped characters)')
-
     parser.add_argument('--proxy', help='Proxy to connect through')
 
     command = None

--- a/scalyr
+++ b/scalyr
@@ -301,7 +301,7 @@ def output_encoded(message):
 # Send a request to the server, and return the parsed JSON response.
 # args: Our parsed command-line arguments
 # uri: Request path for this RPC, e.g. "api/query"
-# parametetDict: The dictionary to be sent (JSON-encoded) to the server as the request body
+# parameterDict: The dictionary to be sent (JSON-encoded) to the server as the request body
 def sendRequest(args, uri, parameterDict):
     parameterJson = json.dumps(parameterDict)
 
@@ -952,7 +952,6 @@ def scalyrToolCli():
                         help='URL for the Scalyr API server. Defaults to https://www.scalyr.com. If you are using eu.scalyr.com then this should be set to https://eu.scalyr.com.')
     parser.add_argument('--token', default='',
                         help='API access token. Use - to read from stdin (query commands only).')
-
     parser.add_argument('--verbose', action='store_true', default=False,
                         help='enables additional diagnostic output')
     parser.add_argument('--dryrun', action='store_true', default=False,

--- a/scalyr
+++ b/scalyr
@@ -227,23 +227,20 @@ def parse_timestamp(timestamp_str):
 
 
 # Return the API token from the command line or environment variables.
-# Resolution order: --token-stdin / --token-fd > --token > env var
-def getApiToken(args, environmentVariableName, permissionType):
-    fd = 0 if args.token_stdin else args.token_fd  # token_stdin is a convenience alias for fd 0 (stdin)
-    if fd is not None:
-        try:
-            with os.fdopen(fd, 'r') as f:
-                return f.read().strip()
-        except OSError as e:
-            print_stderr('Error reading token from fd %d: %s' % (fd, e))
+# Resolution order: --token > env var
+def getApiToken(args, env_variable_name, permission_type, stdin_ok=False):
+    if args.token == '-':
+        if not stdin_ok:
+            print_stderr('--token - (stdin) is not supported for this command.')
             sys.exit(1)
+        return sys.stdin.readline().strip()
 
     api_token = args.token
     if api_token == '':
-        api_token = os.getenv(environmentVariableName, '')
+        api_token = os.getenv(env_variable_name, '')
     if api_token == '':
-        print_stderr('Please specify an API token granting ' + permissionType + ' permission. You can place it in the')
-        print_stderr('command line as --token "XXX", or in the environment variable "' + environmentVariableName + '".')
+        print_stderr('Please specify an API token granting ' + permission_type + ' permission. You can place it in the')
+        print_stderr('command line as --token "XXX", or in the environment variable "' + env_variable_name + '".')
         print_stderr('Use of an environment variable is recommended, to avoid displaying your API token in the')
         print_stderr('console or your command history. You can find API tokens at https://www.scalyr.com/keys.')
         sys.exit(1)
@@ -529,7 +526,7 @@ def commandQuery(parser):
         sys.exit(1)
 
     # Get the API token.
-    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs')
+    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs', stdin_ok=True)
 
     params = {
         "token": apiToken,
@@ -716,7 +713,7 @@ def commandTail(parser):
 
     # Get the API token
     args = parser.parse_args()
-    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs')
+    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs', stdin_ok=True)
 
     try:
         liveTail(apiToken, args)
@@ -744,7 +741,7 @@ def commandNumericQuery(parser):
     args = parser.parse_args()
 
     # Get the API token.
-    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs')
+    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs', stdin_ok=True)
 
     # Send the query to the server.
     response, rawResponse = sendRequest(args, '/api/numericQuery', {
@@ -799,7 +796,7 @@ def commandFacetQuery(parser):
     args = parser.parse_args()
 
     # Get the API token.
-    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs')
+    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs', stdin_ok=True)
 
     # Send the query to the server.
     response, rawResponse = sendRequest(args, '/api/facetQuery', {
@@ -863,7 +860,7 @@ def commandPowerQuery(parser):
     args = parser.parse_args()
 
     # Get the API token.
-    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs')
+    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs', stdin_ok=True)
 
     # Send the query to the server.
     response, rawResponse = sendRequest(args, '/api/powerQuery', {
@@ -904,7 +901,7 @@ def commandTimeseriesQuery(parser):
     args = parser.parse_args()
 
     # Get the API token.
-    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs')
+    apiToken = getApiToken(args, 'scalyr_readlog_token', 'Read Logs', stdin_ok=True)
 
     # build the query
     query = {
@@ -954,11 +951,8 @@ def scalyrToolCli():
     parser.add_argument('--server',
                         help='URL for the Scalyr API server. Defaults to https://www.scalyr.com. If you are using eu.scalyr.com then this should be set to https://eu.scalyr.com.')
     parser.add_argument('--token', default='',
-                        help='API access token')
-    parser.add_argument('--token-stdin', action='store_true', default=False,
-                        help='Read API token from stdin (avoids argv exposure). Example: echo $TOKEN | scalyr query ... --token-stdin')
-    parser.add_argument('--token-fd', type=int, metavar='FD',  # returns None when not supplied
-                        help='Read API token from an open file descriptor (avoids argv exposure). Example: scalyr query ... --token-fd 3 3< <(cat ~/.scalyr-token)')
+                        help='API access token. Use - to read from stdin (query commands only).')
+
     parser.add_argument('--verbose', action='store_true', default=False,
                         help='enables additional diagnostic output')
     parser.add_argument('--dryrun', action='store_true', default=False,


### PR DESCRIPTION
Motivation: the current `--token <value>` argument exposes the API token in the OS process argument list for the full duration of the call. The existing `scalyr_readlog_token` env var avoids the argv exposure, but env vars are inherited by all subprocesses and enumerable via `env`/`printenv` when exported for a whole shell session.

The setup this PR is trying to enable: `security find-generic-password -a "<some_user>" -s "<some_key>" -w | scalyr query '<some_filter>' --token-stdin`

--

Added new options to pass `--token-stdin` via STDIN, and similarly `--token-fd N` (which is only needed for `put-file` as that's the only operation that takes STDIN already).

Other changes:
* Updated README with the added options
* Updated `.gitignore` to skip `__pycache__/`