### PR TITLE
Support put-file reading a file instead of STDIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,16 +473,15 @@ Complete argument list:
 
 ## Creating or updating configuration files
 
-The "put-file" command allows you to create or overwrite a configuration file, taking the new
-file content from stdin.
+The "put-file" command allows you to create or overwrite a configuration file.
 
 Using the put-file command is simple:
 
     # Overwrite the alerts file
-    scalyr put-file /alerts < alerts.json
+    scalyr put-file /alerts --local-path alerts.json
 
     # Create or overwrite the "Foo" dashboard
-    scalyr put-file /dashboards/Foo < fooDashboard.json
+    scalyr put-file /dashboards/Foo --local-path fooDashboard.json
 
 Complete argument list:
 
@@ -497,9 +496,13 @@ Complete argument list:
     --proxy=<ip>:<port>
         An address to connect through when using a proxy. If not set will also take the value from one of the following
         environment variables if any are set: http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY
+    --local-path=xxx
+        Path to a local file whose contents will be uploaded. Use this instead of piping content via stdin.
     --validate
         Validate if input is a valid HOCON. Validation relies on pyhocon parser
         (see https://github.com/chimpler/pyhocon).
+
+Note: Piping file content via stdin is deprecated. Use `--local-path` instead.
 
 ## Deleting configuration files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 140

--- a/scalyr
+++ b/scalyr
@@ -419,12 +419,18 @@ def commandPutFile(parser):
     # Parse the command-line arguments.
     parser.add_argument('filepath',
                         help='server pathname of the file to upload, e.g. "/scalyr/alerts"')
-    parser.add_argument('--validate',
-                        action='store_true',
+    parser.add_argument('--validate', action='store_true',
                         help='validate if input is a valid HOCON')
+    parser.add_argument('--local-path',
+                        help='path to a local file whose contents will be uploaded; use this instead of piping content via stdin')
     args = parser.parse_args()
 
-    content = sys.stdin.read()
+    if args.local_path:
+        with open(args.local_path, 'r') as f:
+            content = f.read()
+    else:
+        print_stderr('WARNING: piping file content via stdin is deprecated, switch to using `--local-path` instead.')
+        content = sys.stdin.read()
     if args.validate:
 
         from importlib import import_module


### PR DESCRIPTION
Reading from STDIN in `put-file` command is possibly conflicting with reading a token from STDIN. Deprecate STDIN usage in `put-file` and give an option to read from a file directly.